### PR TITLE
Fix: Terminal execution of Ctrl + C does not terminate the process

### DIFF
--- a/src/reporters/fancy.ts
+++ b/src/reporters/fancy.ts
@@ -12,6 +12,15 @@ const logUpdate = new LogUpdate()
 let lastRender = Date.now()
 
 export default class FancyReporter implements Reporter {
+  constructor() {
+    if (process) {
+      process.on('SIGINT', () => {
+        const exitCode = process.exit(1)
+        process.kill(exitCode, 'SIGINT')
+      })
+    }
+  }
+  
   allDone () {
     logUpdate.done()
   }


### PR DESCRIPTION
When the fancy reporter is running, it cannot exit the terminal correctly.